### PR TITLE
Unicode compliant urlencode

### DIFF
--- a/geocoders/geonames.py
+++ b/geocoders/geonames.py
@@ -1,11 +1,12 @@
 from utils import simplejson, geocoder_factory
 import urllib
+from django.utils.http import urlencode
 
 # http://www.geonames.org/export/geonames-search.html
 
 def geocode(q):
     data = simplejson.load(urllib.urlopen(
-        'http://ws.geonames.org/searchJSON?' + urllib.urlencode({
+        'http://ws.geonames.org/searchJSON?' + urlencode({
             'q': q,
             'maxRows': 1,
             'lang': 'en',

--- a/geocoders/google.py
+++ b/geocoders/google.py
@@ -1,11 +1,12 @@
 import urllib
+from django.utils.http import urlencode
 from utils import simplejson, geocoder_factory
 
 # http://code.google.com/apis/maps/documentation/geocoding/index.html
 
 def geocode(q, api_key):
     json = simplejson.load(urllib.urlopen(
-        'http://maps.google.com/maps/geo?' + urllib.urlencode({
+        'http://maps.google.com/maps/geo?' + urlencode({
             'q': q,
             'output': 'json',
             'oe': 'utf8',

--- a/geocoders/multimap.py
+++ b/geocoders/multimap.py
@@ -1,11 +1,12 @@
 import urllib
+from django.utils.http import urlencode
 from utils import simplejson, geocoder_factory
 
 # http://www.multimap.com/openapidocs/1.2/web_service/ws_geocoding.htm
 
 def geocode(q, api_key):
     base_url = 'http://developer.multimap.com/API/geocode/1.2/%s' % urllib.quote(api_key)
-    json = simplejson.load(urllib.urlopen(base_url + '?' + urllib.urlencode({
+    json = simplejson.load(urllib.urlopen(base_url + '?' + urlencode({
             'qs': q,
             'output': 'json'
         })

--- a/geocoders/nominatim.py
+++ b/geocoders/nominatim.py
@@ -1,4 +1,5 @@
 import urllib
+from django.utils.http import urlencode
 from utils import simplejson, geocoder_factory
 
 def geocode(q, email):
@@ -10,7 +11,7 @@ def geocode(q, email):
     """
 
     json = simplejson.load(urllib.urlopen(
-        'http://nominatim.openstreetmap.org/search?' + urllib.urlencode({
+        'http://nominatim.openstreetmap.org/search?' + urlencode({
             'q': q,
             'format': 'json',
             'email': email

--- a/geocoders/placemaker.py
+++ b/geocoders/placemaker.py
@@ -1,5 +1,6 @@
 from utils import make_nsfind, ET, geocoder_factory
 import urllib
+from django.utils.http import urlencode
 
 # http://developer.yahoo.com/geo/placemaker/guide/api_docs.html
 
@@ -13,7 +14,7 @@ def geocode(q, api_key):
         'appid': api_key,
     }
     et = ET.parse(urllib.urlopen(
-        'http://wherein.yahooapis.com/v1/document', urllib.urlencode(args))
+        'http://wherein.yahooapis.com/v1/document', urlencode(args))
     )
     place = find(et, 'ns:document/ns:placeDetails/ns:place')
     if place is None:

--- a/geocoders/yahoo.py
+++ b/geocoders/yahoo.py
@@ -1,12 +1,13 @@
 from utils import make_nsfind, ET, geocoder_factory
 import urllib
+from django.utils.http import urlencode
 
 # http://developer.yahoo.com/maps/rest/V1/geocode.html
 
 def geocode(q, api_key):
     find = make_nsfind({'ns': 'urn:yahoo:maps'})
     args = {'location': q, 'appid': api_key}
-    url = 'http://local.yahooapis.com/MapsService/V1/geocode?%s' % urllib.urlencode(args)
+    url = 'http://local.yahooapis.com/MapsService/V1/geocode?%s' % urlencode(args)
     et = ET.parse(urllib.urlopen(url))
     
     result = find(et, '//ns:Result')


### PR DESCRIPTION
Hi Simon, thanks for making your geocoding library available (and er thanks for Django and all that as well ;-)

I encountered a bug when taking Geonames locations (like "Pnom Pen, Krŏng Phnum Pénh, Cambodia") and then sending them back up through the geocoder using your libraries - the urlencode function used was the Python default one, rather than the Django unicode aware version. So I switched it over and it seems to work nicely.

I have only tested it with the Geonames wrapper so far but I changed all of the scripts because presumably they all work the same way. Let me know if you would like me to be a bit more rigorous about that before accepting the request!

Thanks again,

Brendan.
